### PR TITLE
Switch to certbot from APT

### DIFF
--- a/get-cert.sh
+++ b/get-cert.sh
@@ -1,9 +1,7 @@
 # Setup TLS with certbot and Let's Encrypt
 # https://certbot.eff.org/
 
-sudo snap install core; sudo snap refresh core
-sudo snap install --classic certbot
-sudo ln -s /snap/bin/certbot /usr/bin/certbot
+sudo apt install certbot python3-certbot-nginx
 sudo certbot --nginx
 sudo certbot renew --dry-run
 


### PR DESCRIPTION
Fixes #25 

Certbot is in repositories of both Debian and Ubuntu:
```
$ curl -sSo - https://packages.ubuntu.com/jammy/allpackages | grep certbot
<dt><a href='certbot' id='certbot'>certbot</a> (1.21.0-1build1) [<strong class='pmarker'>universe</strong>]</dt>
...
$ curl -sSo - https://packages.debian.org/bookworm/allpackages | grep certbot
<dt><a href='certbot' id='certbot'>certbot</a> (2.1.0-4)</dt>
...
```